### PR TITLE
TB-702. abac filter check

### DIFF
--- a/trood/contrib/django/tests/test_abac_permissions.py
+++ b/trood/contrib/django/tests/test_abac_permissions.py
@@ -19,7 +19,7 @@ from trood.contrib.django.auth.permissions import TroodABACPermission
 request_factory = APIRequestFactory()
 
 
-class MockModel(Model):
+class MockModelOnlyID(Model):
     id = IntegerField()
 
 
@@ -76,5 +76,5 @@ def test_wildcard_sbj_id_rule_filter():
             }]}}}))
     request.data = None
     request.abac.check_permited(request, view)
-    query = MockModel.objects.filter(*request.abac.filters).query
-    assert str(query) == 'SELECT "tests_mockmodel"."id", "tests_mockmodel"."id" FROM "tests_mockmodel" WHERE "tests_mockmodel"."id" = 1'
+    query = MockModelOnlyID.objects.filter(*request.abac.filters).query
+    assert str(query) == 'SELECT "tests_mockmodel"."id" FROM "tests_mockmodel" WHERE "tests_mockmodel"."id" = 1'

--- a/trood/contrib/django/tests/test_abac_permissions.py
+++ b/trood/contrib/django/tests/test_abac_permissions.py
@@ -20,7 +20,7 @@ request_factory = APIRequestFactory()
 
 
 class MockModelOnlyID(Model):
-    id = IntegerField()
+    pass
 
 
 class MyView(APIView):
@@ -77,4 +77,4 @@ def test_wildcard_sbj_id_rule_filter():
     request.data = None
     request.abac.check_permited(request, view)
     query = MockModelOnlyID.objects.filter(*request.abac.filters).query
-    assert str(query) == 'SELECT "tests_mockmodel"."id" FROM "tests_mockmodel" WHERE "tests_mockmodel"."id" = 1'
+    assert str(query) == 'SELECT "tests_mockmodelonlyid"."id" FROM "tests_mockmodelonlyid" WHERE "tests_mockmodelonlyid"."id" = 1'

--- a/trood/contrib/django/tests/test_renderer.py
+++ b/trood/contrib/django/tests/test_renderer.py
@@ -45,4 +45,4 @@ def test_can_mask_simple_field():
         'request': request,
         'response': response,
     })
-    assert 'field_to_hide' not in json.loads(response)
+    assert 'field_to_hide' not in json.loads(response)[0]


### PR DESCRIPTION
https://trood-cis.atlassian.net/browse/TB-702

Проблема из задачи возникает только на master - в текущей dev-версии запрос к действию-wildcard формируется корректно - с фильтром. Написан тест. 
+ исправил деталь в одном из тестов - поле для скрытия искалось в массиве, а не в конкретном объекте. Соответственно, тест всегда проходил успешно, даже при наличии поля. 